### PR TITLE
v2.0.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,30 @@
+# Disable all metrics.
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false

--- a/lib/cleverbot.rb
+++ b/lib/cleverbot.rb
@@ -1,4 +1,4 @@
-require 'clever/client'
+require 'cleverbot/client'
 
 # Cleverbot
 module Cleverbot

--- a/lib/cleverbot.rb
+++ b/lib/cleverbot.rb
@@ -1,52 +1,5 @@
-require 'json'
-require 'rest-client'
+require 'clever/client'
 
-# Defines Cleverbot.
-class Cleverbot
-  # @return [String] The API Key for the instance.
-  attr_reader :api_key
-
-  # Creates a new instance of the Cleverbot.
-  # @param api_key [String] The API key for the Cleverbot API.
-  def initialize(api_key)
-    @api_key = api_key
-    url = "http://cleverbot.com/getreply?key=#{@api_key}&wrapper=cleverbot_rb"
-    response = { 'output' => nil }
-    10.times do
-      response = RestClient.get(url)
-      response = JSON.parse(response)
-      break unless response['output'].nil?
-    end
-    @cs = response['cs']
-  end
-
-  # Sends the bot a message and returns its response.
-  # @param str [String] The message to send to the bot.
-  # @return [String] The bot's response, or its error message.
-  def say(str)
-    url = "http://cleverbot.com/getreply?key=#{@api_key}&input=#{str}&cs=#{@cs}&wrapper=cleverbot_rb"
-    response = { 'output' => nil }
-    10.times do
-      begin
-        response = RestClient.get(url)
-        response = JSON.parse(response)
-      rescue
-        reset
-      end
-      break unless response['output'].nil?
-    end
-    @cs = response['cs']
-    response['output']
-  end
-
-  def reset
-    url = "http://cleverbot.com/getreply?key=#{@api_key}&wrapper=cleverbot_rb"
-    response = { 'output' => nil }
-    10.times do
-      response = RestClient.get(url)
-      response = JSON.parse(response)
-      break unless response['output'].nil?
-    end
-    @cs = response['cs']
-  end
+# Cleverbot
+module Cleverbot
 end

--- a/lib/cleverbot/api.rb
+++ b/lib/cleverbot/api.rb
@@ -1,0 +1,51 @@
+require 'rest-client'
+require 'json'
+
+module Cleverbot
+  # Wrapper for Cleverbot's REST API
+  module API
+    # Base API url
+    API_URL = 'http://cleverbot.com'.freeze
+
+    # Name of the library
+    WRAPPER = 'cleverbot_rb'.freeze
+
+    # The most time to wait to retry for a response
+    # from the API in seconds. This is because, at the time of
+    # writing, the API will sometimes return an empty response
+    # and you must retry your request.
+    MAX_BACKOFF = 60
+
+    module_function
+
+    # Executre a GET request.
+    # @param route [String] the route to request
+    # @param params [Hash] the params to query
+    def get_request(route = '', params = {})
+      params[:wrapper] = WRAPPER
+      response = RestClient.get "#{API_URL}/#{route}", params: params.compact
+      JSON.parse response
+    end
+
+    # @param key [String] API key
+    # @param input [String] the phrase to pass to the conversation
+    # @param conversation [String] the conversation ID to pass input to
+    # @param retry_empty [true, false] whether to retry if we get an empty response
+    # @param backoff [Integer] how long to wait before retrying if retry_empty
+    # @return [String] the reply
+    def get_reply(key, input, conversation = nil, retry_empty: true, backoff: 1)
+      return if backoff > MAX_BACKOFF
+
+      reply = get_request(
+        'getreply',
+        key: key, input: input, cs: conversation
+      )
+
+      return reply unless retry_empty && reply['output'].nil?
+      puts "Reponse empty! Retrying after #{backoff} seconds."
+      sleep backoff
+
+      get_reply(key, input, conversation, retry_empty: true, backoff: backoff * 2)
+    end
+  end
+end

--- a/lib/cleverbot/client.rb
+++ b/lib/cleverbot/client.rb
@@ -1,4 +1,4 @@
-require 'cleverbot/data'
+require 'cleverbot/conversation'
 
 module Cleverbot
   # A client that wraps basic API functionality and can maintain

--- a/lib/cleverbot/client.rb
+++ b/lib/cleverbot/client.rb
@@ -46,7 +46,7 @@ module Cleverbot
     # @param identifier [thing] identifier to associate this converation with
     # @return [String] the response
     def say(message, identifier = :default)
-      convo = conversation(identifier) || Conversation.new(key)
+      convo = conversation(identifier) || Conversation.new(@key)
       convo.reply message
     end
 

--- a/lib/cleverbot/client.rb
+++ b/lib/cleverbot/client.rb
@@ -1,0 +1,62 @@
+require 'cleverbot/data'
+
+module Cleverbot
+  # A client that wraps basic API functionality and can maintain
+  # multiple conversations associated with an identifier
+  # @example Basic conversing
+  #   client = Cleverbot::Client.new 'your api key'
+  #   puts client.say 'hello' #=> *witty response*
+  #   puts client.say 'okay' #=> *another witty response*
+  # @example Multiple conversations
+  #   client = Cleverbot::Client.new 'your api key'
+  #
+  #   # Client#say takes an arbitray identifier as a second arguement
+  #   # that will start a new conversation with each unique object
+  #   # given, and continue that conversation when passed the same identifier.
+  #
+  #   # Start a new conversation with Mike the symbol
+  #   puts client.say('hello', :mike) #=> 'hello'
+  #   puts client.say('my name is mike', :mike) #=> 'ok'
+  #
+  #   # Start a new conversation with Zac the string.
+  #   puts client.say('hello', 'Zac') #=> 'hello'
+  #   puts client.say('my name is mike', 'Zac') #=> 'no it is zac'
+  class Client
+    # @return [String] API key used to make requests with this Client
+    attr_reader :key
+
+    # @return [Hash<thing, Conversation>] the conversations initiated by this client
+    attr_reader :conversations
+
+    # Create a new Client
+    # @param key [String] API key
+    def initialize(key)
+      @key = key
+      @conversations = {}
+    end
+
+    # @param identifier [thing] identifier to search for
+    # @return [Conversation] the conversation associated with this identifier
+    def conversation(identifier = :default)
+      @conversations[identifier]
+    end
+
+    # Say something to the API
+    # @param message [String] what to say
+    # @param identifier [thing] identifier to associate this converation with
+    # @return [String] the response
+    # @raise [ArgumentError] if message is empty
+    def say(message, identifier = :default)
+      raise ArgumentError, 'message cannot be empty' if message.empty?
+
+      convo = conversation identifier
+      if convo
+        convo.reply key, message
+      else
+        new_convo = Conversation.new message
+        @conversations[identifier] = new_convo
+        new_convo.response
+      end
+    end
+  end
+end

--- a/lib/cleverbot/client.rb
+++ b/lib/cleverbot/client.rb
@@ -47,7 +47,7 @@ module Cleverbot
     # @return [String] the response
     def say(message, identifier = :default)
       convo = conversation(identifier) || Conversation.new(key)
-      convo.reply key, message
+      convo.reply message
     end
 
     # Deletes a conversation

--- a/lib/cleverbot/client.rb
+++ b/lib/cleverbot/client.rb
@@ -46,7 +46,7 @@ module Cleverbot
     # @param identifier [thing] identifier to associate this converation with
     # @return [String] the response
     def say(message, identifier = :default)
-      convo = conversation(identifier) || Conversation.new(@key)
+      convo = conversation(identifier) || Conversation.new(key)
       convo.reply message
     end
 

--- a/lib/cleverbot/client.rb
+++ b/lib/cleverbot/client.rb
@@ -47,6 +47,8 @@ module Cleverbot
     # @return [String] the response
     def say(message, identifier = :default)
       convo = conversation(identifier) || Conversation.new(key)
+      @conversations[identifier] = convo
+
       convo.reply message
     end
 

--- a/lib/cleverbot/client.rb
+++ b/lib/cleverbot/client.rb
@@ -58,5 +58,12 @@ module Cleverbot
         new_convo.response
       end
     end
+
+    # Deletes a conversation
+    # @param identifier [thing] identifier associated with the conversation
+    # @return [Conversation] the removed conversation
+    def delete(identifier = :default)
+      @conversations.delete identifier
+    end
   end
 end

--- a/lib/cleverbot/client.rb
+++ b/lib/cleverbot/client.rb
@@ -45,18 +45,9 @@ module Cleverbot
     # @param message [String] what to say
     # @param identifier [thing] identifier to associate this converation with
     # @return [String] the response
-    # @raise [ArgumentError] if message is empty
     def say(message, identifier = :default)
-      raise ArgumentError, 'message cannot be empty' if message.empty?
-
-      convo = conversation identifier
-      if convo
-        convo.reply key, message
-      else
-        new_convo = Conversation.new message
-        @conversations[identifier] = new_convo
-        new_convo.response
-      end
+      convo = conversation(identifier) || Conversation.new(key)
+      convo.reply key, message
     end
 
     # Deletes a conversation

--- a/lib/cleverbot/conversation.rb
+++ b/lib/cleverbot/conversation.rb
@@ -39,7 +39,7 @@ module Cleverbot
     # @raise [ArgumentError] if message is empty
     def reply(message)
       raise ArgumentError, 'message cannot be empty' if message.empty?
-      update_data API.get_reply key, message, cs
+      update_data API.get_reply @key, message, cs
     end
 
     # Internally updates this conversation's data

--- a/lib/cleverbot/conversation.rb
+++ b/lib/cleverbot/conversation.rb
@@ -79,7 +79,7 @@ module Cleverbot
         end
       end
 
-      @interaction_count = data['interaction_count']
+      @interaction_count = data['interaction_count'].to_i
     end
   end
 end

--- a/lib/cleverbot/conversation.rb
+++ b/lib/cleverbot/conversation.rb
@@ -40,6 +40,7 @@ module Cleverbot
     def reply(message)
       raise ArgumentError, 'message cannot be empty' if message.empty?
       update_data API.get_reply @key, message, cs
+      output
     end
 
     # Internally updates this conversation's data

--- a/lib/cleverbot/conversation.rb
+++ b/lib/cleverbot/conversation.rb
@@ -60,7 +60,8 @@ module Cleverbot
         data['time_day'],
         data['time_hour'],
         data['time_minute'],
-        data['time_second']
+        data['time_second'],
+        0
       )
 
       @interactions = []

--- a/lib/cleverbot/conversation.rb
+++ b/lib/cleverbot/conversation.rb
@@ -28,14 +28,16 @@ module Cleverbot
     # @return [Hash] all raw data about this conversation
     attr_reader :data
 
-    def initialize(data)
-      update_data(data)
+    # Start a new conversation with the API
+    # @param key [String] the API key used for this conversation
+    def initialize(key)
+      @key = key
     end
 
     # Replies to this conversation thread.
-    # @param key [String] the API key to make this reply with
     # @param message [String] the message to send
-    def reply(key, message)
+    # @raise [ArgumentError] if message is empty
+    def reply(message)
       raise ArgumentError, 'message cannot be empty' if message.empty?
       update_data API.get_reply key, message, cs
     end

--- a/lib/cleverbot/conversation.rb
+++ b/lib/cleverbot/conversation.rb
@@ -1,0 +1,82 @@
+require 'cleverbot/api'
+
+module Cleverbot
+  # A conversation with the API
+  class Conversation
+    # @return [String] this conversation's hash, assigned by cleverbot
+    attr_reader :cs
+
+    # @return [String] the input given to this interaction
+    attr_reader :input
+
+    # @return [String] the output to this interaction
+    attr_reader :output
+    alias response output
+
+    # @return [Time] timestamp of this interaction
+    attr_reader :timestamp
+
+    # @return [Array<Hash>] interaction history in this conversation
+    attr_reader :interactions
+
+    # @return [Integer] number of interactions
+    attr_reader :interaction_count
+
+    # The API returns a lot of other arbitray information that may or may not
+    # be useful. The most common pieces of data have direct instance methods ;
+    # for anything else, look inside this hash.
+    # @return [Hash] all raw data about this conversation
+    attr_reader :data
+
+    def initialize(data)
+      update_data(data)
+    end
+
+    # Replies to this conversation thread.
+    # @param key [String] the API key to make this reply with
+    # @param message [String] the message to send
+    def reply(key, message)
+      raise ArgumentError, 'message cannot be empty' if message.empty?
+      update_data API.get_reply key, message, cs
+    end
+
+    # Internally updates this conversation's data
+    # @param data [Hash] an API response hash to update from
+    private def update_data(data)
+      @data = data
+
+      @cs = data['cs']
+
+      @input = data['input']
+
+      @output = data['output']
+
+      @timestamp = Time.new(
+        data['time_year'],
+        data['time_month'],
+        data['time_day'],
+        data['time_hour'],
+        data['time_minute'],
+        data['time_second']
+      )
+
+      @interactions = []
+
+      data.select { |k, _| k.start_with? 'interaction_' }.each do |k, v|
+        next if v.empty?
+
+        index = v[/\d+/].to_i
+
+        @interactions[index] ||= {}
+
+        if k.match?(/interaction_\d+$/)
+          @interactions[index][:input] = v
+        elsif k.match?(/interaction_\d+_output/)
+          @interactions[index][:output] = v
+        end
+      end
+
+      @interaction_count = data['interaction_count']
+    end
+  end
+end

--- a/lib/cleverbot/conversation.rb
+++ b/lib/cleverbot/conversation.rb
@@ -66,15 +66,15 @@ module Cleverbot
       @interactions = []
 
       data.select { |k, _| k.start_with? 'interaction_' }.each do |k, v|
-        next if v.empty?
+        next if v.empty? || k == 'interaction_count'
 
-        index = v[/\d+/].to_i
+        index = k[/\d+/].to_i - 1
 
         @interactions[index] ||= {}
 
         if k.match?(/interaction_\d+$/)
           @interactions[index][:input] = v
-        elsif k.match?(/interaction_\d+_output/)
+        elsif k.match?(/interaction_\d+_other$/)
           @interactions[index][:output] = v
         end
       end


### PR DESCRIPTION
# v2.0.0

This update wraps the Cleverbot API in a more helpful way, as well as provide some additional functionality, and more useful data objects.

Quoting the example in the new docs:

## Basic conversing
```ruby
client = Cleverbot::Client.new 'your api key'
puts client.say 'hello' #=> *witty response*
puts client.say 'okay' #=> *another witty response*
```

## Multiple conversations
```ruby
client = Cleverbot::Client.new 'your api key'

# Client#say takes an arbitray identifier as a second arguement
# that will start a new conversation with each unique object
# given, and continue that conversation when passed the same identifier.

# Start a new conversation with Mike the symbol
puts client.say('hello', :mike) #=> 'hello'
puts client.say('my name is mike', :mike) #=> 'ok'

# Start a new conversation with Zac the string.
puts client.say('hello', 'Zac') #=> 'hello'
puts client.say('my name is mike', 'Zac') #=> 'no it is zac'
```

### To-Do

- [ ] Review
- [ ] Test
- [ ] Update README
- [ ] Bump version number
- [ ] Merge